### PR TITLE
chore: use fmt.Errorf instead of errors.Wrap

### DIFF
--- a/apierrors.go
+++ b/apierrors.go
@@ -24,8 +24,8 @@ import (
 var (
 	ProvisionWarehouseTimeout = "ProvisionWarehouseTimeout"
 
-	ErrDoRequest    = errors.New("DoReqeustFailed")
-	ErrReadResponse = errors.New("ReadResponseFailed")
+	ErrDoRequest    = errors.New("failed to do request")
+	ErrReadResponse = errors.New("failed to read response")
 )
 
 type APIErrorResponseBody struct {


### PR DESCRIPTION
it seems that `errors.Wrap` was introduced before `fmt.Errorf()` in the stdlib was introduced.

the current error message is like:

```
context canceled: DoRequestFailed
```

the convention is becoming to put the root cause part into the right side, for example:

```
do request failed: context canceled
```