### PR TITLE
fix: support dsn contains special character

### DIFF
--- a/dsn_test.go
+++ b/dsn_test.go
@@ -1,12 +1,39 @@
 package godatabend
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParseDSNWithEncodedChars(t *testing.T) {
+	username := "test_user"
+	password := "pa$$?word:abc@123"
+	dsn := fmt.Sprintf("databend+https://%s:%s@host:443/db?param1=value1&param2=value2", url.QueryEscape(username), url.QueryEscape(password))
+	cfg, err := ParseDSN(dsn)
+	require.Nil(t, err)
+
+	assert.Equal(t, username, cfg.User)
+	assert.Equal(t, password, cfg.Password)
+	assert.Equal(t, "host:443", cfg.Host)
+	assert.Equal(t, "db", cfg.Database)
+}
+func TestParseDSNWithSpecialChars(t *testing.T) {
+	dsn := "databend+https://use%#$^&r:pa$$?word@host:443/db?param1=value1&param2=value2"
+	cfg, err := ParseDSN(dsn)
+	require.Nil(t, err)
+
+	assert.Equal(t, "use%#$^&r", cfg.User)
+	assert.Equal(t, "pa$$?word", cfg.Password)
+	assert.Equal(t, "host:443", cfg.Host)
+	assert.Equal(t, "db", cfg.Database)
+	assert.Equal(t, "value1", cfg.Params["param1"])
+	assert.Equal(t, "value2", cfg.Params["param2"])
+}
 
 func TestFormatDSN(t *testing.T) {
 	dsn := "databend+https://username:password@tn3ftqihs.ch.aws-us-east-2.default.databend.com/test?role=test_role&empty_field_as=null&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&warehouse=wh&sessionParam1=sessionValue1"


### PR DESCRIPTION
- Fix username and password contains special char like `use%#$^&r"` .
- Support use encoded username and password in dsn.