### PR TITLE
feat: return geo values as bytes or strings by geometry_output_format

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,15 @@ The following table outlines the mapping between Databend types and Go types:
 | Bitmap             | string    |
 | Decimal            | decimal.Decimal|
 | String             | string    |
+| Geometry           | string / []byte |
+| Geography          | string / []byte |
 | Date               | time.Time |
 | DateTime           | time.Time |
 | Array(T)           | string    |
 | Tuple(T1, T2, ...) | string    |
 | Variant            | string    |
+
+`Geometry` and `Geography` follow the current `geometry_output_format` setting. `WKB` and `EWKB` return `[]byte`; `WKT`, `EWKT`, and `GEOJSON` return `string`.
 
 ## Compatibility
 

--- a/arrow.go
+++ b/arrow.go
@@ -253,13 +253,9 @@ func arrowRecordToRows(record arrow.Record, fields *[]DataField, settings *Setti
 		}
 	}
 
-	location := time.UTC
-	if settings != nil && settings.TimeZone != "" {
-		loc, err := time.LoadLocation(settings.TimeZone)
-		if err != nil {
-			return nil, err
-		}
-		location = loc
+	opts, err := queryResponseColumnTypeOptions(settings)
+	if err != nil {
+		return nil, err
 	}
 
 	descs := make([]*TypeDesc, len(*fields))
@@ -285,7 +281,7 @@ func arrowRecordToRows(record arrow.Record, fields *[]DataField, settings *Setti
 				continue
 			}
 
-			typedValue, err := materializeArrowDriverValue(descs[colIdx], column, rowIdx, location)
+			typedValue, err := materializeArrowDriverValue(descs[colIdx], column, rowIdx, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -311,9 +307,9 @@ func formatArrowColumnValue(desc *TypeDesc, column arrow.Array, rowIdx int, loca
 	return formatArrowValue(desc, marshaled.GetOneForMarshal(rowIdx), location)
 }
 
-func materializeArrowDriverValue(desc *TypeDesc, column arrow.Array, rowIdx int, location *time.Location) (driver.Value, error) {
+func materializeArrowDriverValue(desc *TypeDesc, column arrow.Array, rowIdx int, opts *ColumnTypeOptions) (driver.Value, error) {
 	if desc == nil {
-		return formatArrowColumnValue(desc, column, rowIdx, location)
+		return formatArrowColumnValue(desc, column, rowIdx, opts.timezone)
 	}
 
 	switch desc.Name {
@@ -322,11 +318,29 @@ func materializeArrowDriverValue(desc *TypeDesc, column arrow.Array, rowIdx int,
 	case "Date":
 		return materializeArrowDateDriverValue(column, rowIdx)
 	case "Timestamp":
-		return materializeArrowTimestampDriverValue(column, rowIdx, location)
+		return materializeArrowTimestampDriverValue(column, rowIdx, opts.timezone)
 	case "Timestamp_Tz":
-		return materializeArrowTimestampTZDriverValue(column, rowIdx, location)
+		return materializeArrowTimestampTZDriverValue(column, rowIdx, opts.timezone)
+	case "Geometry", "Geography":
+		return materializeArrowGeoDriverValue(desc.Name, column, rowIdx, opts.geometryOutputFormat)
 	default:
-		return formatArrowColumnValue(desc, column, rowIdx, location)
+		return formatArrowColumnValue(desc, column, rowIdx, opts.timezone)
+	}
+}
+
+func materializeArrowGeoDriverValue(kind string, column arrow.Array, rowIdx int, format geoOutputFormat) (driver.Value, error) {
+	marshaled, ok := column.(marshaledArrowArray)
+	if !ok {
+		return nil, fmt.Errorf("arrow column does not support row materialization: %T", column)
+	}
+
+	switch value := marshaled.GetOneForMarshal(rowIdx).(type) {
+	case []byte:
+		return materializeGeoFromBinary(kind, value, format)
+	case string:
+		return materializeGeoFromString(kind, value, format)
+	default:
+		return nil, fmt.Errorf("unsupported arrow %s value type %T", strings.ToLower(kind), value)
 	}
 }
 

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -196,6 +196,71 @@ func TestDecodeArrowResponseMaterializesTimestampTZ(t *testing.T) {
 	assert.Equal(t, -8*3600, offset)
 }
 
+func TestDecodeArrowResponseMaterializesGeo(t *testing.T) {
+	textValue := `{"type":"Point","coordinates":[60,37]}`
+	binaryValue := []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 78, 64, 0, 0, 0, 0, 0, 128, 66, 64}
+
+	testCases := []struct {
+		name     string
+		field    arrow.Field
+		settings *Settings
+		input    []byte
+		want     any
+	}{
+		{
+			name: "geometry-wkb",
+			field: arrow.Field{
+				Name: "geom",
+				Type: arrow.BinaryTypes.LargeBinary,
+				Metadata: arrow.NewMetadata(
+					[]string{arrowExtensionKey},
+					[]string{arrowExtensionGeometry},
+				),
+			},
+			settings: &Settings{GeometryOutputFormat: "WKB"},
+			input:    binaryValue,
+			want:     binaryValue,
+		},
+		{
+			name: "geography-geojson",
+			field: arrow.Field{
+				Name: "geog",
+				Type: arrow.BinaryTypes.LargeBinary,
+				Metadata: arrow.NewMetadata(
+					[]string{arrowExtensionKey},
+					[]string{arrowExtensionGeography},
+				),
+			},
+			settings: &Settings{GeometryOutputFormat: "GEOJSON"},
+			input:    []byte(textValue),
+			want:     textValue,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := QueryResponse{
+				ID:       "query-geo",
+				Settings: tc.settings,
+				Schema:   &[]DataField{{Name: tc.field.Name, Type: dataTypeNameFromGeoExtension(tc.field)}},
+			}
+
+			payload := buildArrowPayload(t, resp, []arrow.Field{tc.field}, func(builder *arrowarray.RecordBuilder) {
+				builder.Field(0).(*arrowarray.BinaryBuilder).Append(tc.input)
+			})
+
+			decoded, err := decodeQueryResponse(&rawHTTPResponse{
+				headers: http.Header{contentType: []string{arrowStreamContentType}},
+				body:    payload,
+			})
+			require.NoError(t, err)
+			require.Len(t, decoded.typedRows, 1)
+			require.Len(t, decoded.typedRows[0], 1)
+			assert.Equal(t, tc.want, decoded.typedRows[0][0])
+		})
+	}
+}
+
 func TestQuerySyncUsesHTTPArrowAcrossPages(t *testing.T) {
 	type requestSnapshot struct {
 		SQL       string
@@ -508,6 +573,22 @@ func buildArrowPayload(t *testing.T, response QueryResponse, fields []arrow.Fiel
 	require.NoError(t, writer.Write(record))
 	require.NoError(t, writer.Close())
 	return buf.Bytes()
+}
+
+func dataTypeNameFromGeoExtension(field arrow.Field) string {
+	value, ok := field.Metadata.GetValue(arrowExtensionKey)
+	if !ok {
+		return ""
+	}
+
+	switch value {
+	case arrowExtensionGeometry:
+		return "Geometry"
+	case arrowExtensionGeography:
+		return "Geography"
+	default:
+		return ""
+	}
 }
 
 func testHTTPConfig(t *testing.T, rawURL string) *Config {

--- a/columntype.go
+++ b/columntype.go
@@ -109,6 +109,35 @@ func (c *simpleColumnType) ScanType() reflect.Type {
 	return c.scanType
 }
 
+type geoColumnType struct {
+	dbType string
+	format geoOutputFormat
+	columnTypeDefault
+	isNullable
+}
+
+func (c geoColumnType) Parse(s string) (driver.Value, error) {
+	if c.checkNull(s) {
+		return nil, nil
+	}
+	return materializeGeoFromString(c.dbType, s, c.format)
+}
+
+func (c geoColumnType) ScanType() reflect.Type {
+	if c.format.returnsBinary() {
+		return reflect.TypeOf([]byte(nil))
+	}
+	return reflectTypeString
+}
+
+func (c geoColumnType) DatabaseTypeName() string {
+	return c.wrapName(c.dbType)
+}
+
+func (c geoColumnType) Desc() *TypeDesc {
+	return &TypeDesc{Name: c.dbType, Nullable: bool(c.isNullable)}
+}
+
 type timestampColumnType struct {
 	tz *time.Location
 	columnTypeDefault
@@ -252,6 +281,8 @@ func NewColumnType(dbType string, opts *ColumnTypeOptions) (ColumnType, error) {
 		return &timestampTzColumnType{isNullable: nullable}, nil
 	case "Date":
 		return &dateColumnType{isNullable: nullable}, nil
+	case "Geometry", "Geography":
+		return &geoColumnType{dbType: desc.Name, format: opts.geometryOutputFormat, isNullable: nullable}, nil
 	case "Decimal":
 		precision, err := strconv.ParseInt(desc.Args[0].Name, 10, 64)
 		if err != nil {
@@ -268,14 +299,16 @@ func NewColumnType(dbType string, opts *ColumnTypeOptions) (ColumnType, error) {
 }
 
 type ColumnTypeOptions struct {
-	formatNullAsStr bool
-	timezone        *time.Location
+	formatNullAsStr      bool
+	timezone             *time.Location
+	geometryOutputFormat geoOutputFormat
 }
 
 func defaultColumnTypeOptions() *ColumnTypeOptions {
 	return &ColumnTypeOptions{
-		formatNullAsStr: false,
-		timezone:        time.UTC,
+		formatNullAsStr:      false,
+		timezone:             time.UTC,
+		geometryOutputFormat: geoOutputFormatGeoJSON,
 	}
 }
 
@@ -285,4 +318,8 @@ func (opt *ColumnTypeOptions) SetFormatNullAsStr(v bool) {
 
 func (opt *ColumnTypeOptions) SetTimezone(v *time.Location) {
 	opt.timezone = v
+}
+
+func (opt *ColumnTypeOptions) SetGeometryOutputFormat(v string) {
+	opt.geometryOutputFormat = parseGeoOutputFormat(v)
 }

--- a/columntype_test.go
+++ b/columntype_test.go
@@ -17,6 +17,7 @@ func TestColumnType(t *testing.T) {
 		typeDesc string
 		input    string
 		want     any
+		settings *Settings
 	}{
 		{typeDesc: "String", input: "123", want: "123"},
 		{typeDesc: "Nullable(String)", input: "123", want: "123"},
@@ -34,10 +35,15 @@ func TestColumnType(t *testing.T) {
 		{typeDesc: "Timestamp", input: "2025-01-16 02:01:26.739219", want: time.Date(2025, 1, 16, 2, 1, 26, 739219000, time.UTC)},
 		{typeDesc: "Date", input: "2025-01-16", want: time.Date(2025, 1, 16, 0, 0, 0, 0, time.UTC)},
 		{typeDesc: "Decimal(10, 2)", input: "123.45", want: "123.45"},
+		{typeDesc: "Geometry", input: "01010000000000000000004E400000000000804240", want: []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 78, 64, 0, 0, 0, 0, 0, 128, 66, 64}, settings: &Settings{GeometryOutputFormat: "WKB"}},
+		{typeDesc: "Geography", input: "POINT(60 37)", want: "POINT(60 37)", settings: &Settings{GeometryOutputFormat: "WKT"}},
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("%s::%s", tc.input, tc.typeDesc), func(t *testing.T) {
-			colType, err := NewColumnType(tc.typeDesc, nil)
+			opts, err := queryResponseColumnTypeOptions(tc.settings)
+			require.NoError(t, err)
+
+			colType, err := NewColumnType(tc.typeDesc, opts)
 			require.NoError(t, err)
 
 			v, err := colType.Parse(tc.input)
@@ -45,7 +51,7 @@ func TestColumnType(t *testing.T) {
 			require.True(t, driver.IsValue(v))
 
 			if tc.want != nil {
-				require.Equal(t, reflect.TypeOf(tc.want).Name(), colType.ScanType().Name())
+				require.Equal(t, reflect.TypeOf(tc.want), colType.ScanType())
 			}
 
 			desc, err := ParseTypeDesc(tc.typeDesc)
@@ -56,16 +62,17 @@ func TestColumnType(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, desc, desc2)
 
-			runScan(t, tc.typeDesc, tc.input, tc.want)
+			runScan(t, tc.typeDesc, tc.input, tc.want, tc.settings)
 		})
 	}
 }
 
-func runScan(t *testing.T, desc string, input string, want any) {
+func runScan(t *testing.T, desc string, input string, want any, settings *Settings) {
 	db := sql.OpenDB(&fakeConnector{
 		resp: &QueryResponse{
-			Schema: &[]DataField{{Name: "x", Type: desc}},
-			Data:   [][]*string{{&input}},
+			Settings: settings,
+			Schema:   &[]DataField{{Name: "x", Type: desc}},
+			Data:     [][]*string{{&input}},
 		},
 	})
 
@@ -130,14 +137,6 @@ func (s *fakeStmt) NumInput() int {
 }
 
 func (s *fakeStmt) Query(args []driver.Value) (driver.Rows, error) {
-	schema, err := parse_schema(s.resp.Schema, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return &nextRows{
-		dc:           &DatabendConn{},
-		respData:     s.resp,
-		resultSchema: *schema,
-	}, nil
+	dc := &DatabendConn{cfg: &Config{}}
+	return dc.newNextRows(context.Background(), s.resp)
 }

--- a/connection.go
+++ b/connection.go
@@ -31,12 +31,20 @@ type DatabendConn struct {
 	rest   *APIClient
 }
 
-func (dc *DatabendConn) columnTypeOptions(location *time.Location) *ColumnTypeOptions {
+func (dc *DatabendConn) columnTypeOptions(settings *Settings, location *time.Location) *ColumnTypeOptions {
 	opts := defaultColumnTypeOptions()
 	if location != nil {
 		opts.SetTimezone(location)
 	} else if dc.cfg.Location != nil {
 		opts.SetTimezone(dc.cfg.Location)
+	}
+	if dc.cfg != nil && dc.cfg.Params != nil {
+		if format, ok := dc.cfg.Params["geometry_output_format"]; ok {
+			opts.SetGeometryOutputFormat(format)
+		}
+	}
+	if settings != nil {
+		opts.SetGeometryOutputFormat(settings.GeometryOutputFormat)
 	}
 	return opts
 }

--- a/geo.go
+++ b/geo.go
@@ -1,0 +1,56 @@
+package godatabend
+
+import (
+	"database/sql/driver"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+type geoOutputFormat uint8
+
+const (
+	geoOutputFormatGeoJSON geoOutputFormat = iota
+	geoOutputFormatWKB
+	geoOutputFormatWKT
+	geoOutputFormatEWKB
+	geoOutputFormatEWKT
+)
+
+func parseGeoOutputFormat(s string) geoOutputFormat {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "WKB":
+		return geoOutputFormatWKB
+	case "WKT":
+		return geoOutputFormatWKT
+	case "EWKB":
+		return geoOutputFormatEWKB
+	case "EWKT":
+		return geoOutputFormatEWKT
+	default:
+		return geoOutputFormatGeoJSON
+	}
+}
+
+func (f geoOutputFormat) returnsBinary() bool {
+	return f == geoOutputFormatWKB || f == geoOutputFormatEWKB
+}
+
+func materializeGeoFromString(kind, value string, format geoOutputFormat) (driver.Value, error) {
+	if !format.returnsBinary() {
+		return value, nil
+	}
+
+	raw, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode %s hex value: %w", strings.ToLower(kind), err)
+	}
+	return raw, nil
+}
+
+func materializeGeoFromBinary(_ string, value []byte, format geoOutputFormat) (driver.Value, error) {
+	if format.returnsBinary() {
+		return append([]byte(nil), value...), nil
+	}
+	return string(value), nil
+}

--- a/result_rows.go
+++ b/result_rows.go
@@ -9,7 +9,11 @@ import (
 
 func queryResponseColumnTypeOptions(settings *Settings) (*ColumnTypeOptions, error) {
 	opts := defaultColumnTypeOptions()
-	if settings == nil || settings.TimeZone == "" {
+	if settings == nil {
+		return opts, nil
+	}
+	opts.SetGeometryOutputFormat(settings.GeometryOutputFormat)
+	if settings.TimeZone == "" {
 		return opts, nil
 	}
 

--- a/result_rows_test.go
+++ b/result_rows_test.go
@@ -1,6 +1,7 @@
 package godatabend
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -47,4 +48,55 @@ func TestDecodeJSONResponseMaterializesTypedRows(t *testing.T) {
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	require.NoError(t, err)
 	assert.Equal(t, time.Date(2025, 1, 16, 10, 1, 26, 739219000, loc), ts)
+}
+
+func TestDecodeJSONResponseMaterializesGeoRows(t *testing.T) {
+	wkb, err := hex.DecodeString("01010000000000000000004E400000000000804240")
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name     string
+		typ      string
+		settings *Settings
+		input    string
+		want     any
+	}{
+		{
+			name:     "geometry-wkb",
+			typ:      "Geometry",
+			settings: &Settings{GeometryOutputFormat: "WKB"},
+			input:    "01010000000000000000004E400000000000804240",
+			want:     wkb,
+		},
+		{
+			name:     "geography-geojson",
+			typ:      "Geography",
+			settings: &Settings{GeometryOutputFormat: "GEOJSON"},
+			input:    `{"type":"Point","coordinates":[60,37]}`,
+			want:     `{"type":"Point","coordinates":[60,37]}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := QueryResponse{
+				ID:       "json-geo-query",
+				Settings: tc.settings,
+				Schema:   &[]DataField{{Name: "g", Type: tc.typ}},
+				Data:     [][]*string{{strPtr(tc.input)}},
+			}
+
+			body, err := json.Marshal(resp)
+			require.NoError(t, err)
+
+			decoded, err := decodeQueryResponse(&rawHTTPResponse{
+				headers: http.Header{contentType: []string{jsonContentType}},
+				body:    body,
+			})
+			require.NoError(t, err)
+			require.Len(t, decoded.typedRows, 1)
+			require.Len(t, decoded.typedRows[0], 1)
+			assert.Equal(t, tc.want, decoded.typedRows[0][0])
+		})
+	}
 }

--- a/rows.go
+++ b/rows.go
@@ -92,7 +92,7 @@ func (dc *DatabendConn) newNextRows(ctx context.Context, resp *QueryResponse) (r
 		}
 	}
 
-	schema, err := parse_schema(resp.Schema, dc.columnTypeOptions(location))
+	schema, err := parse_schema(resp.Schema, dc.columnTypeOptions(resp.Settings, location))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/type_test.go
+++ b/tests/type_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	databend "github.com/datafuselabs/databend-go"
 	"golang.org/x/mod/semver"
@@ -240,5 +241,56 @@ func (s *DatabendTestSuite) TestDecimal() {
 	s.r.NoError(err)
 	s.r.Equal("12345.6789", output)
 
+	s.r.NoError(rows.Close())
+}
+
+func (s *DatabendTestSuite) TestGeo() {
+	if semver.Compare(driverVersion, "v0.9.0") <= 0 {
+		return
+	}
+
+	db := sql.OpenDB(s.cfg)
+	defer db.Close()
+
+	const (
+		wkbHex       = "01010000000000000000004e400000000000804240"
+		geometryWKT  = "POINT(60 37)"
+		geographyWKT = "POINT(60 37)"
+	)
+
+	rows, err := db.Query("settings(geometry_output_format='WKB') SELECT to_geometry('POINT(60 37)'), to_geography('POINT(60 37)')")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	columnTypes, err := rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 2)
+	s.r.Equal("Geometry", columnTypes[0].DatabaseTypeName())
+	s.r.Equal("Geography", columnTypes[1].DatabaseTypeName())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[0].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[1].ScanType())
+
+	var geomWKB, geogWKB []byte
+	err = rows.Scan(&geomWKB, &geogWKB)
+	s.r.NoError(err)
+	s.r.Equal(wkbHex, hex.EncodeToString(geomWKB))
+	s.r.Equal(wkbHex, hex.EncodeToString(geogWKB))
+	s.r.NoError(rows.Close())
+
+	rows, err = db.Query("settings(geometry_output_format='WKT') SELECT to_geometry('POINT(60 37)'), to_geography('POINT(60 37)')")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	columnTypes, err = rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 2)
+	s.r.Equal(reflect.TypeOf(""), columnTypes[0].ScanType())
+	s.r.Equal(reflect.TypeOf(""), columnTypes[1].ScanType())
+
+	var geomText, geogText string
+	err = rows.Scan(&geomText, &geogText)
+	s.r.NoError(err)
+	s.r.Equal(geometryWKT, geomText)
+	s.r.Equal(geographyWKT, geogText)
 	s.r.NoError(rows.Close())
 }


### PR DESCRIPTION
 ## Summary

  Align `databend-go` geo result decoding with `bendsql`.

  `Geometry` and `Geography` values now return either `[]byte` or `string` based on the current `geometry_output_format`:

  - `WKB` / `EWKB` -> `[]byte`
  - `WKT` / `EWKT` / `GEOJSON` -> `string`

  This behavior now applies consistently across:

  - JSON result decoding
  - Arrow result decoding
  - `database/sql` `ColumnTypes().ScanType()`

  ## Changes

  - Added geo output format parsing and helper materialization logic
  - Introduced dedicated geo column type handling for `Geometry` and `Geography`
  - Updated JSON row materialization to decode WKB/EWKB hex strings into `[]byte`
  - Updated Arrow row materialization to return raw binary for WKB/EWKB and UTF-8 strings for text formats
  - Passed `geometry_output_format` through `Settings` -> `ColumnTypeOptions` -> row decoding / scan type inference
  - Updated README type mapping docs for geo types

  ## Tests

  Added coverage for:

  - JSON geo decoding
  - Arrow geo decoding
  - `ColumnTypes().ScanType()` switching between `[]byte` and `string`
  - integration queries for `to_geometry(...)` and `to_geography(...)` under both `WKB` and `WKT`

