### PR TITLE
feat: support binary type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ The following table outlines the mapping between Databend types and Go types:
 | Float32            | float32   |
 | Float64            | float64   |
 | Bitmap             | string    |
+| Binary             | []byte    |
 | Decimal            | decimal.Decimal|
 | String             | string    |
 | Geometry           | string / []byte |
@@ -229,6 +230,8 @@ The following table outlines the mapping between Databend types and Go types:
 | Array(T)           | string    |
 | Tuple(T1, T2, ...) | string    |
 | Variant            | string    |
+
+`Binary` is returned as raw `[]byte`. If you scan it into `string`, `database/sql` applies its default `[]byte` to `string` conversion; this does not reformat the value using `binary_output_format`.
 
 `Geometry` and `Geography` follow the current `geometry_output_format` setting. `WKB` and `EWKB` return `[]byte`; `WKT`, `EWKT`, and `GEOJSON` return `string`.
 

--- a/arrow.go
+++ b/arrow.go
@@ -315,6 +315,8 @@ func materializeArrowDriverValue(desc *TypeDesc, column arrow.Array, rowIdx int,
 	switch desc.Name {
 	case "Null":
 		return nil, nil
+	case "Binary":
+		return materializeArrowBinaryDriverValue(column, rowIdx)
 	case "Date":
 		return materializeArrowDateDriverValue(column, rowIdx)
 	case "Timestamp":
@@ -325,6 +327,22 @@ func materializeArrowDriverValue(desc *TypeDesc, column arrow.Array, rowIdx int,
 		return materializeArrowGeoDriverValue(desc.Name, column, rowIdx, opts.geometryOutputFormat)
 	default:
 		return formatArrowColumnValue(desc, column, rowIdx, opts.timezone)
+	}
+}
+
+func materializeArrowBinaryDriverValue(column arrow.Array, rowIdx int) (driver.Value, error) {
+	marshaled, ok := column.(marshaledArrowArray)
+	if !ok {
+		return nil, fmt.Errorf("arrow column does not support row materialization: %T", column)
+	}
+
+	switch value := marshaled.GetOneForMarshal(rowIdx).(type) {
+	case []byte:
+		return materializeBinaryFromBinary(value), nil
+	case string:
+		return []byte(value), nil
+	default:
+		return nil, fmt.Errorf("unsupported arrow binary value type %T", value)
 	}
 }
 

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -261,6 +261,30 @@ func TestDecodeArrowResponseMaterializesGeo(t *testing.T) {
 	}
 }
 
+func TestDecodeArrowResponseMaterializesBinary(t *testing.T) {
+	input := []byte("hello")
+	resp := QueryResponse{
+		ID:       "query-binary",
+		Settings: &Settings{BinaryOutputFormat: "BASE64"},
+		Schema:   &[]DataField{{Name: "bin", Type: "Binary"}},
+	}
+
+	payload := buildArrowPayload(t, resp, []arrow.Field{
+		{Name: "bin", Type: arrow.BinaryTypes.Binary},
+	}, func(builder *arrowarray.RecordBuilder) {
+		builder.Field(0).(*arrowarray.BinaryBuilder).Append(input)
+	})
+
+	decoded, err := decodeQueryResponse(&rawHTTPResponse{
+		headers: http.Header{contentType: []string{arrowStreamContentType}},
+		body:    payload,
+	})
+	require.NoError(t, err)
+	require.Len(t, decoded.typedRows, 1)
+	require.Len(t, decoded.typedRows[0], 1)
+	assert.Equal(t, input, decoded.typedRows[0][0])
+}
+
 func TestQuerySyncUsesHTTPArrowAcrossPages(t *testing.T) {
 	type requestSnapshot struct {
 		SQL       string

--- a/binary.go
+++ b/binary.go
@@ -1,0 +1,80 @@
+package godatabend
+
+import (
+	"database/sql/driver"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+type binaryOutputFormat uint8
+
+const (
+	binaryOutputFormatHex binaryOutputFormat = iota
+	binaryOutputFormatBase64
+	binaryOutputFormatUTF8
+	binaryOutputFormatUTF8Lossy
+)
+
+type httpJSONResultMode uint8
+
+const (
+	httpJSONResultModeDriver httpJSONResultMode = iota
+	httpJSONResultModeDisplay
+)
+
+func parseBinaryOutputFormat(s string) binaryOutputFormat {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "BASE64":
+		return binaryOutputFormatBase64
+	case "UTF-8", "UTF8":
+		return binaryOutputFormatUTF8
+	case "UTF-8-LOSSY", "UTF8-LOSSY":
+		return binaryOutputFormatUTF8Lossy
+	default:
+		return binaryOutputFormatHex
+	}
+}
+
+func parseHTTPJSONResultMode(s string) httpJSONResultMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "display":
+		return httpJSONResultModeDisplay
+	default:
+		return httpJSONResultModeDriver
+	}
+}
+
+func materializeBinaryFromString(value string, format binaryOutputFormat, mode httpJSONResultMode) (driver.Value, error) {
+	// Databend HTTP API uses driver mode by default, where Binary cells are encoded as hex
+	// regardless of binary_output_format.
+	if mode != httpJSONResultModeDisplay {
+		raw, err := hex.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode binary hex value: %w", err)
+		}
+		return raw, nil
+	}
+
+	switch format {
+	case binaryOutputFormatBase64:
+		raw, err := base64.StdEncoding.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode binary base64 value: %w", err)
+		}
+		return raw, nil
+	case binaryOutputFormatUTF8, binaryOutputFormatUTF8Lossy:
+		return []byte(value), nil
+	default:
+		raw, err := hex.DecodeString(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode binary hex value: %w", err)
+		}
+		return raw, nil
+	}
+}
+
+func materializeBinaryFromBinary(value []byte) driver.Value {
+	return append([]byte(nil), value...)
+}

--- a/columntype.go
+++ b/columntype.go
@@ -138,6 +138,32 @@ func (c geoColumnType) Desc() *TypeDesc {
 	return &TypeDesc{Name: c.dbType, Nullable: bool(c.isNullable)}
 }
 
+type binaryColumnType struct {
+	format binaryOutputFormat
+	mode   httpJSONResultMode
+	columnTypeDefault
+	isNullable
+}
+
+func (c binaryColumnType) Parse(s string) (driver.Value, error) {
+	if c.checkNull(s) {
+		return nil, nil
+	}
+	return materializeBinaryFromString(s, c.format, c.mode)
+}
+
+func (binaryColumnType) ScanType() reflect.Type {
+	return reflect.TypeOf([]byte(nil))
+}
+
+func (c binaryColumnType) DatabaseTypeName() string {
+	return c.wrapName("Binary")
+}
+
+func (c binaryColumnType) Desc() *TypeDesc {
+	return &TypeDesc{Name: "Binary", Nullable: bool(c.isNullable)}
+}
+
 type timestampColumnType struct {
 	tz *time.Location
 	columnTypeDefault
@@ -281,6 +307,8 @@ func NewColumnType(dbType string, opts *ColumnTypeOptions) (ColumnType, error) {
 		return &timestampTzColumnType{isNullable: nullable}, nil
 	case "Date":
 		return &dateColumnType{isNullable: nullable}, nil
+	case "Binary":
+		return &binaryColumnType{format: opts.binaryOutputFormat, mode: opts.httpJSONResultMode, isNullable: nullable}, nil
 	case "Geometry", "Geography":
 		return &geoColumnType{dbType: desc.Name, format: opts.geometryOutputFormat, isNullable: nullable}, nil
 	case "Decimal":
@@ -302,6 +330,8 @@ type ColumnTypeOptions struct {
 	formatNullAsStr      bool
 	timezone             *time.Location
 	geometryOutputFormat geoOutputFormat
+	binaryOutputFormat   binaryOutputFormat
+	httpJSONResultMode   httpJSONResultMode
 }
 
 func defaultColumnTypeOptions() *ColumnTypeOptions {
@@ -309,6 +339,8 @@ func defaultColumnTypeOptions() *ColumnTypeOptions {
 		formatNullAsStr:      false,
 		timezone:             time.UTC,
 		geometryOutputFormat: geoOutputFormatGeoJSON,
+		binaryOutputFormat:   binaryOutputFormatHex,
+		httpJSONResultMode:   httpJSONResultModeDriver,
 	}
 }
 
@@ -322,4 +354,12 @@ func (opt *ColumnTypeOptions) SetTimezone(v *time.Location) {
 
 func (opt *ColumnTypeOptions) SetGeometryOutputFormat(v string) {
 	opt.geometryOutputFormat = parseGeoOutputFormat(v)
+}
+
+func (opt *ColumnTypeOptions) SetBinaryOutputFormat(v string) {
+	opt.binaryOutputFormat = parseBinaryOutputFormat(v)
+}
+
+func (opt *ColumnTypeOptions) SetHTTPJSONResultMode(v string) {
+	opt.httpJSONResultMode = parseHTTPJSONResultMode(v)
 }

--- a/columntype_test.go
+++ b/columntype_test.go
@@ -35,6 +35,8 @@ func TestColumnType(t *testing.T) {
 		{typeDesc: "Timestamp", input: "2025-01-16 02:01:26.739219", want: time.Date(2025, 1, 16, 2, 1, 26, 739219000, time.UTC)},
 		{typeDesc: "Date", input: "2025-01-16", want: time.Date(2025, 1, 16, 0, 0, 0, 0, time.UTC)},
 		{typeDesc: "Decimal(10, 2)", input: "123.45", want: "123.45"},
+		{typeDesc: "Binary", input: "616263", want: []byte("abc")},
+		{typeDesc: "Binary", input: "YWJj", want: []byte("abc"), settings: &Settings{BinaryOutputFormat: "BASE64", HTTPJSONResultMode: "display"}},
 		{typeDesc: "Geometry", input: "01010000000000000000004E400000000000804240", want: []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 78, 64, 0, 0, 0, 0, 0, 128, 66, 64}, settings: &Settings{GeometryOutputFormat: "WKB"}},
 		{typeDesc: "Geography", input: "POINT(60 37)", want: "POINT(60 37)", settings: &Settings{GeometryOutputFormat: "WKT"}},
 	}
@@ -88,6 +90,24 @@ func runScan(t *testing.T, desc string, input string, want any, settings *Settin
 	err = rows.Scan(a)
 	require.NoError(t, err)
 	require.Equal(t, want, reflect.ValueOf(a).Elem().Interface())
+}
+
+func TestBinaryScanIntoStringUsesDatabaseSQLDefaultConversion(t *testing.T) {
+	db := sql.OpenDB(&fakeConnector{
+		resp: &QueryResponse{
+			typedRows: [][]driver.Value{{[]byte("hello")}},
+			Schema:    &[]DataField{{Name: "x", Type: "Binary"}},
+		},
+	})
+
+	rows, err := db.Query("x")
+	require.NoError(t, err)
+	require.True(t, rows.Next())
+
+	var out string
+	err = rows.Scan(&out)
+	require.NoError(t, err)
+	require.Equal(t, "hello", out)
 }
 
 type fakeConnector struct {

--- a/connection.go
+++ b/connection.go
@@ -42,9 +42,17 @@ func (dc *DatabendConn) columnTypeOptions(settings *Settings, location *time.Loc
 		if format, ok := dc.cfg.Params["geometry_output_format"]; ok {
 			opts.SetGeometryOutputFormat(format)
 		}
+		if format, ok := dc.cfg.Params["binary_output_format"]; ok {
+			opts.SetBinaryOutputFormat(format)
+		}
+		if mode, ok := dc.cfg.Params["http_json_result_mode"]; ok {
+			opts.SetHTTPJSONResultMode(mode)
+		}
 	}
 	if settings != nil {
 		opts.SetGeometryOutputFormat(settings.GeometryOutputFormat)
+		opts.SetBinaryOutputFormat(settings.BinaryOutputFormat)
+		opts.SetHTTPJSONResultMode(settings.HTTPJSONResultMode)
 	}
 	return opts
 }

--- a/query.go
+++ b/query.go
@@ -36,6 +36,8 @@ type DataField struct {
 type Settings struct {
 	TimeZone             string `json:"timezone"`
 	GeometryOutputFormat string `json:"geometry_output_format"`
+	BinaryOutputFormat   string `json:"binary_output_format"`
+	HTTPJSONResultMode   string `json:"http_json_result_mode"`
 }
 
 type QueryResponse struct {

--- a/result_rows.go
+++ b/result_rows.go
@@ -13,6 +13,8 @@ func queryResponseColumnTypeOptions(settings *Settings) (*ColumnTypeOptions, err
 		return opts, nil
 	}
 	opts.SetGeometryOutputFormat(settings.GeometryOutputFormat)
+	opts.SetBinaryOutputFormat(settings.BinaryOutputFormat)
+	opts.SetHTTPJSONResultMode(settings.HTTPJSONResultMode)
 	if settings.TimeZone == "" {
 		return opts, nil
 	}

--- a/result_rows_test.go
+++ b/result_rows_test.go
@@ -100,3 +100,54 @@ func TestDecodeJSONResponseMaterializesGeoRows(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeJSONResponseMaterializesBinaryRows(t *testing.T) {
+	testCases := []struct {
+		name     string
+		settings *Settings
+		input    string
+		want     []byte
+	}{
+		{
+			name:     "driver-mode-hex",
+			settings: &Settings{BinaryOutputFormat: "BASE64", HTTPJSONResultMode: "driver"},
+			input:    "616263",
+			want:     []byte("abc"),
+		},
+		{
+			name:     "display-mode-base64",
+			settings: &Settings{BinaryOutputFormat: "BASE64", HTTPJSONResultMode: "display"},
+			input:    "YWJj",
+			want:     []byte("abc"),
+		},
+		{
+			name:     "display-mode-utf8",
+			settings: &Settings{BinaryOutputFormat: "UTF-8", HTTPJSONResultMode: "display"},
+			input:    "abc",
+			want:     []byte("abc"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := QueryResponse{
+				ID:       "json-binary-query",
+				Settings: tc.settings,
+				Schema:   &[]DataField{{Name: "b", Type: "Binary"}},
+				Data:     [][]*string{{strPtr(tc.input)}},
+			}
+
+			body, err := json.Marshal(resp)
+			require.NoError(t, err)
+
+			decoded, err := decodeQueryResponse(&rawHTTPResponse{
+				headers: http.Header{contentType: []string{jsonContentType}},
+				body:    body,
+			})
+			require.NoError(t, err)
+			require.Len(t, decoded.typedRows, 1)
+			require.Len(t, decoded.typedRows[0], 1)
+			assert.Equal(t, tc.want, decoded.typedRows[0][0])
+		})
+	}
+}

--- a/tests/type_test.go
+++ b/tests/type_test.go
@@ -294,3 +294,38 @@ func (s *DatabendTestSuite) TestGeo() {
 	s.r.Equal(geographyWKT, geogText)
 	s.r.NoError(rows.Close())
 }
+
+func (s *DatabendTestSuite) TestBinary() {
+	if semver.Compare(driverVersion, "v0.9.0") <= 0 {
+		return
+	}
+
+	db := sql.OpenDB(s.cfg)
+	defer db.Close()
+
+	rows, err := db.Query("settings(binary_output_format='base64') SELECT to_binary('hello')")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	columnTypes, err := rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 1)
+	s.r.Equal("Binary", columnTypes[0].DatabaseTypeName())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[0].ScanType())
+
+	var raw []byte
+	err = rows.Scan(&raw)
+	s.r.NoError(err)
+	s.r.Equal([]byte("hello"), raw)
+	s.r.NoError(rows.Close())
+
+	rows, err = db.Query("settings(binary_output_format='base64') SELECT to_binary('hello')")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	var text string
+	err = rows.Scan(&text)
+	s.r.NoError(err)
+	s.r.Equal("hello", text)
+	s.r.NoError(rows.Close())
+}


### PR DESCRIPTION
## Summary

  Add dedicated `Binary` result handling in `databend-go` and make query results return raw `[]byte`
  values consistently across JSON and Arrow decoding.

  This aligns the Go driver with the raw-bytes behavior used by `bendsql` for binary values, while
  keeping `database/sql` behavior explicit and predictable.

  ## Changes

  - Added `Binary`-specific materialization helpers
  - Added `binary_output_format` and `http_json_result_mode` to query response settings
  - Added a dedicated `Binary` column type in the Go driver
  - Made `ColumnTypes().ScanType()` return `[]byte` for `Binary`
  - Updated JSON result decoding to materialize raw bytes
  - Updated Arrow result decoding to materialize raw bytes
  - Kept `Scan(&string)` behavior as the default `database/sql` conversion from `[]byte` to `string`
  - Documented the `Binary` type mapping and scan behavior in the README

  ## Behavior Notes

  - `Scan(&[]byte)` is the recommended way to read `Binary` values
  - `Scan(&string)` does **not** reformat the value using `binary_output_format`
  - For HTTP JSON responses:
    - `driver` mode binary cells are still decoded from hex
    - `display` mode binary cells are decoded according to `binary_output_format`

  ## Tests

  Added coverage for:

  - `Binary` column type parsing and `ScanType()`
  - JSON binary result decoding in both `driver` and `display` modes
  - Arrow binary result decoding to raw bytes
  - integration queries that verify:
    - `Scan(&[]byte)` returns raw bytes
    - `Scan(&string)` follows default `database/sql` conversion behavior