### PR TITLE
test: stabilize integration suite and expand type coverage

### DIFF
--- a/client_integration_test.go
+++ b/client_integration_test.go
@@ -1,0 +1,96 @@
+package godatabend
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationResumeQueryWithStatePreservesRows(t *testing.T) {
+	cfg := integrationTestConfig(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	firstClient := NewAPIClientFromConfig(cfg)
+	firstClient.MaxRowsPerPage = 1
+
+	startResp, err := firstClient.StartQuery(ctx, "SELECT number FROM numbers(5) ORDER BY number")
+	require.NoError(t, err)
+	require.NotNil(t, startResp)
+	require.False(t, startResp.ReadFinished())
+
+	state := firstClient.GetState()
+	require.NotNil(t, state)
+	require.NotEmpty(t, state.SessionState)
+
+	secondClient := NewAPIClientFromConfig(cfg).WithState(state)
+	secondClient.MaxRowsPerPage = 1
+
+	finalResp, err := secondClient.PollUntilQueryEnd(ctx, startResp)
+	require.NoError(t, err)
+	require.NotNil(t, finalResp)
+	require.True(t, finalResp.ReadFinished())
+	defer func() {
+		require.NoError(t, secondClient.CloseQuery(context.Background(), finalResp))
+	}()
+
+	for i := 0; i < 5; i++ {
+		value, ok := finalResp.cellString(i, 0)
+		require.True(t, ok)
+		assert.Equal(t, strconv.Itoa(i), value)
+	}
+
+	require.NotNil(t, finalResp.Stats)
+	assert.Equal(t, uint64(5), finalResp.Stats.ResultProgress.Rows)
+}
+
+func TestIntegrationStateRestoresSessionSettings(t *testing.T) {
+	cfg := integrationTestConfig(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	client := NewAPIClientFromConfig(cfg)
+	_, err := client.QuerySync(ctx, "SET max_result_rows = 5")
+	require.NoError(t, err)
+
+	state := client.GetState()
+	require.NotNil(t, state)
+	require.NotEmpty(t, state.SessionState)
+
+	restored := NewAPIClientFromConfig(cfg).WithState(state)
+	resp, err := restored.QuerySync(ctx, "SELECT value FROM system.settings WHERE name = 'max_result_rows'")
+	require.NoError(t, err)
+
+	value, ok := resp.cellString(0, 0)
+	require.True(t, ok)
+	assert.Equal(t, "5", value)
+
+	roundedState := restored.GetState()
+	require.NotNil(t, roundedState)
+	require.NotEmpty(t, roundedState.SessionState)
+
+	var sessionState SessionState
+	require.NoError(t, json.Unmarshal([]byte(roundedState.SessionState), &sessionState))
+	assert.Equal(t, "5", sessionState.Settings["max_result_rows"])
+}
+
+func integrationTestConfig(t *testing.T) *Config {
+	t.Helper()
+
+	dsn := os.Getenv("TEST_DATABEND_DSN")
+	if dsn == "" {
+		t.Skip("TEST_DATABEND_DSN is not set")
+	}
+
+	cfg, err := ParseDSN(dsn)
+	require.NoError(t, err)
+	return cfg
+}

--- a/tests/affected_rows_test.go
+++ b/tests/affected_rows_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -12,20 +13,21 @@ import (
 )
 
 func TestAffectedRows(t *testing.T) {
+	tableName := fmt.Sprintf("books_%d", time.Now().UnixNano())
+	defer cleanupTable(dsn, tableName)
+
 	err := selectExec(dsn)
 	require.NoError(t, err, "select exec failed")
 
-	err = createAffectedTable(dsn)
+	err = createAffectedTable(dsn, tableName)
 	require.NoError(t, err, "create affected table failed")
-	affectedRows, err := updateTable(dsn)
+	affectedRows, err := updateTable(dsn, tableName)
 	require.NoError(t, err, "update table failed")
 	assert.Equal(t, int64(2), affectedRows)
 
-	affectedRowsDelete, err := deleteTable(dsn)
+	affectedRowsDelete, err := deleteTable(dsn, tableName)
 	require.NoError(t, err, "delete table failed")
 	assert.Equal(t, int64(2), affectedRowsDelete)
-
-	defer cleanupTable(dsn)
 }
 
 func selectExec(dsn string) error {
@@ -45,14 +47,14 @@ func selectExec(dsn string) error {
 	return nil
 }
 
-func createAffectedTable(dsn string) error {
+func createAffectedTable(dsn, tableName string) error {
 	db, err := sql.Open("databend", dsn)
 	if err != nil {
 		return fmt.Errorf("failed to connect. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
 
-	query := "CREATE TABLE IF NOT EXISTS books (id INT, title STRING, author STRING)"
+	query := fmt.Sprintf("CREATE TABLE %s (id INT, title STRING, author STRING)", tableName)
 	_, err = db.Exec(query)
 	if err != nil {
 		return fmt.Errorf("failed to create table. %v, err: %v", query, err)
@@ -61,12 +63,12 @@ func createAffectedTable(dsn string) error {
 	fmt.Println("Table created successfully.")
 
 	// Insert sample data
-	_, err = db.Exec("INSERT INTO books (id, title, author) VALUES (1, '1984', 'George Orwell')")
+	_, err = db.Exec(fmt.Sprintf("INSERT INTO %s (id, title, author) VALUES (1, '1984', 'George Orwell')", tableName))
 	if err != nil {
 		return fmt.Errorf("failed to insert data. %v, err: %v", query, err)
 	}
 
-	_, err = db.Exec("INSERT INTO books (id, title, author) VALUES (1, 'To Kill a Mockingbird', 'Harper Lee')")
+	_, err = db.Exec(fmt.Sprintf("INSERT INTO %s (id, title, author) VALUES (1, 'To Kill a Mockingbird', 'Harper Lee')", tableName))
 	if err != nil {
 		return fmt.Errorf("failed to insert data. %v, err: %v", query, err)
 	}
@@ -74,14 +76,14 @@ func createAffectedTable(dsn string) error {
 	return nil
 }
 
-func cleanupTable(dsn string) error {
+func cleanupTable(dsn, tableName string) error {
 	db, err := sql.Open("databend", dsn)
 	if err != nil {
 		return fmt.Errorf("failed to connect. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
 
-	query := "DROP TABLE IF EXISTS books"
+	query := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
 	_, err = db.Exec(query)
 	if err != nil {
 		return fmt.Errorf("failed to drop table. %v, err: %v", query, err)
@@ -90,14 +92,14 @@ func cleanupTable(dsn string) error {
 	return nil
 }
 
-func updateTable(dsn string) (int64, error) {
+func updateTable(dsn, tableName string) (int64, error) {
 	db, err := sql.Open("databend", dsn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to connect. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
 
-	query := "UPDATE books SET title = 'Nineteen Eighty-Four' WHERE id = 1"
+	query := fmt.Sprintf("UPDATE %s SET title = 'Nineteen Eighty-Four' WHERE id = 1", tableName)
 	result, err := db.Exec(query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to update table. %v, err: %v", query, err)
@@ -113,14 +115,14 @@ func updateTable(dsn string) (int64, error) {
 	return rowsAffected, nil
 }
 
-func deleteTable(dsn string) (int64, error) {
+func deleteTable(dsn, tableName string) (int64, error) {
 	db, err := sql.Open("databend", dsn)
 	if err != nil {
 		return 0, fmt.Errorf("failed to connect. %v, err: %v", dsn, err)
 	}
 	defer db.Close()
 
-	query := "DELETE FROM books WHERE id = 1"
+	query := fmt.Sprintf("DELETE FROM %s WHERE id = 1", tableName)
 	result, err := db.Exec(query)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete table. %v, err: %v", query, err)

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -113,10 +113,11 @@ func (s *DatabendTestSuite) SetupTest() {
 	db := sql.OpenDB(s.cfg)
 	defer db.Close()
 	tName := strings.ReplaceAll(t.Name(), "/", "__")
+	uniqueSuffix := time.Now().UnixNano()
 
-	s.table = fmt.Sprintf("test_%s_%d", tName, time.Now().Unix())
+	s.table = fmt.Sprintf("test_%s_%d", strings.ToLower(tName), uniqueSuffix)
 	// t.Logf("setup test with table %s", s.table)
-	s.table2 = fmt.Sprintf("test_%s_%d", tName, time.Now().Unix()+1)
+	s.table2 = fmt.Sprintf("test_%s_%d", strings.ToLower(tName), uniqueSuffix+1)
 
 	_, err := db.Exec(fmt.Sprintf(createTable, s.table))
 	s.r.NoError(err)
@@ -131,9 +132,9 @@ func (s *DatabendTestSuite) TearDownTest() {
 	defer db.Close()
 
 	// t.Logf("teardown test with table %s", s.table)
-	_, err := db.Exec(fmt.Sprintf("DROP TABLE %s", s.table))
+	_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", s.table))
 	s.r.NoError(err)
-	_, err = db.Exec(fmt.Sprintf("DROP TABLE %s", s.table2))
+	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", s.table2))
 	s.r.NoError(err)
 }
 

--- a/tests/nullable_test.go
+++ b/tests/nullable_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"reflect"
 )
 
 func (s *DatabendTestSuite) TestNullable() {
@@ -42,4 +43,43 @@ func (s *DatabendTestSuite) TestQueryNull() {
 	s.r.NoError(err)
 	s.r.False(val.Valid)
 	s.r.Empty(val.String)
+}
+
+func (s *DatabendTestSuite) TestNullableExtendedTypes() {
+	conn := s.Conn()
+	defer conn.Close()
+
+	ctx := context.Background()
+	_, err := conn.ExecContext(ctx, "SET format_null_as_str=0")
+	s.r.NoError(err)
+
+	rows, err := conn.QueryContext(ctx, "settings(binary_output_format='base64', geometry_output_format='WKB') SELECT CAST(NULL AS Binary), CAST(NULL AS Geometry), CAST(NULL AS Geography)")
+	s.r.NoError(err)
+
+	columnTypes, err := rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 3)
+	s.r.Equal("Binary NULL", columnTypes[0].DatabaseTypeName())
+	s.r.Equal("Geometry NULL", columnTypes[1].DatabaseTypeName())
+	s.r.Equal("Geography NULL", columnTypes[2].DatabaseTypeName())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[0].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[1].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[2].ScanType())
+
+	result, err := scanValues(rows)
+	s.r.NoError(err)
+	s.r.Equal([][]any{{nil, nil, nil}}, result)
+	s.r.NoError(rows.Close())
+
+	row := conn.QueryRowContext(ctx, "settings(binary_output_format='base64', geometry_output_format='WKT') SELECT CAST(NULL AS Binary), CAST(NULL AS Geometry), CAST(NULL AS Geography)")
+	var (
+		binaryVal []byte
+		geomText  sql.NullString
+		geogText  sql.NullString
+	)
+	err = row.Scan(&binaryVal, &geomText, &geogText)
+	s.r.NoError(err)
+	s.r.Nil(binaryVal)
+	s.r.False(geomText.Valid)
+	s.r.False(geogText.Valid)
 }

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -35,15 +36,17 @@ func (s *DatabendTestSuite) TestChangeRole() {
 	var result string
 	db := sql.OpenDB(s.cfg)
 	defer db.Close()
+	roleName := strings.ToLower(fmt.Sprintf("test_role_%d", time.Now().UnixNano()))
+	defer func() {
+		_, err := db.Exec(fmt.Sprintf("drop role if exists %s", roleName))
+		r.NoError(err)
+	}()
 
 	err := db.QueryRow("select version()").Scan(&result)
 	r.NoError(err)
-	_, err = db.Exec("drop role if exists test_role")
+	_, err = db.Exec(fmt.Sprintf("drop role if exists %s", roleName))
 	r.NoError(err)
-	_, err = db.Exec("drop role if exists test_role_2")
-	r.NoError(err)
-	println(result)
-	_, err = db.Exec("create role if not exists test_role")
+	_, err = db.Exec(fmt.Sprintf("create role if not exists %s", roleName))
 	r.NoError(err)
 	s.NoError(err)
 
@@ -57,18 +60,23 @@ func (s *DatabendTestSuite) TestChangeRole() {
 	//_, err = db.Exec("grant role 'test_role' to " + user)
 	//r.NoError(err)
 
-	_, err = db.Exec("set role 'test_role'")
+	_, err = db.Exec(fmt.Sprintf("set role '%s'", roleName))
 	r.NoError(err)
 	err = db.QueryRow("select current_role()").Scan(&result)
 	r.NoError(err)
-	r.Equal("test_role", result)
+	r.Equal(roleName, result)
 
-	dsn_with_role := fmt.Sprintf("%s&role=test_role", dsn)
+	separator := "?"
+	if strings.Contains(dsn, "?") {
+		separator = "&"
+	}
+	dsn_with_role := fmt.Sprintf("%s%srole=%s", dsn, separator, roleName)
 	db2, err := sql.Open("databend", dsn_with_role)
 	r.NoError(err)
+	defer db2.Close()
 	err = db2.QueryRow("select current_role()").Scan(&result)
 	r.NoError(err)
-	r.Equal("test_role", result)
+	r.Equal(roleName, result)
 }
 
 func (s *DatabendTestSuite) TestSessionConfig() {

--- a/tests/txn_test.go
+++ b/tests/txn_test.go
@@ -2,24 +2,33 @@ package tests
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTnx(t *testing.T) {
-	selectT := "SELECT * FROM t ORDER BY c;"
+	tableName := fmt.Sprintf("txn_%d", time.Now().UnixNano())
+	selectT := fmt.Sprintf("SELECT * FROM %s ORDER BY c;", tableName)
 	db1, err := sql.Open("databend", dsn)
 	assert.NoError(t, err)
+	defer db1.Close()
 	db2, err := sql.Open("databend", dsn)
 	assert.NoError(t, err)
+	defer db2.Close()
+	defer func() {
+		_, cleanupErr := db1.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s;", tableName))
+		assert.NoError(t, cleanupErr)
+	}()
 
 	// test commit
-	_, err = db1.Exec("CREATE OR REPLACE TABLE t(c int);")
+	_, err = db1.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s(c int);", tableName))
 	assert.NoError(t, err)
 	tx1, err := db1.Begin()
 	assert.NoError(t, err)
-	_, err = tx1.Exec("INSERT INTO t(c) VALUES(1);")
+	_, err = tx1.Exec(fmt.Sprintf("INSERT INTO %s(c) VALUES(1);", tableName))
 	assert.NoError(t, err)
 	rows, err := tx1.Query("select 1")
 	assert.NoError(t, err)
@@ -33,7 +42,7 @@ func TestTnx(t *testing.T) {
 	tx2, err := db2.Begin()
 	assert.NoError(t, err)
 
-	_, err = tx2.Exec("INSERT INTO t(c) VALUES(2);")
+	_, err = tx2.Exec(fmt.Sprintf("INSERT INTO %s(c) VALUES(2);", tableName))
 	assert.NoError(t, err)
 	rows2, err = tx2.Query(selectT)
 	assert.NoError(t, err)
@@ -63,13 +72,13 @@ func TestTnx(t *testing.T) {
 	}
 
 	// test rollback
-	_, err = db1.Exec("DROP table  t;")
+	_, err = db1.Exec(fmt.Sprintf("DROP TABLE %s;", tableName))
 	assert.NoError(t, err)
-	_, err = db1.Exec("CREATE OR REPLACE TABLE t(c int);")
+	_, err = db1.Exec(fmt.Sprintf("CREATE OR REPLACE TABLE %s(c int);", tableName))
 	assert.NoError(t, err)
 	tx1, err = db1.Begin()
 	assert.NoError(t, err)
-	_, err = tx1.Exec("INSERT INTO t(c) VALUES(1);")
+	_, err = tx1.Exec(fmt.Sprintf("INSERT INTO %s(c) VALUES(1);", tableName))
 	assert.NoError(t, err)
 	rows, err = tx1.Query(selectT)
 	assert.NoError(t, err)

--- a/tests/type_test.go
+++ b/tests/type_test.go
@@ -64,6 +64,12 @@ func (s *DatabendTestSuite) TestDate() {
 			rows, err := db.Query(selectSQL)
 			s.r.NoError(err)
 
+			columnTypes, err := rows.ColumnTypes()
+			s.r.NoError(err)
+			s.r.Len(columnTypes, 1)
+			s.r.Equal("Date NULL", columnTypes[0].DatabaseTypeName())
+			s.r.Equal(reflect.TypeOf(time.Time{}), columnTypes[0].ScanType())
+
 			var output time.Time
 			for i := 0; i < 2; i++ {
 				s.r.True(rows.Next())
@@ -128,6 +134,12 @@ func (s *DatabendTestSuite) TestTimestamp() {
 			s.r.True(rows.Next())
 			s.r.NoError(err)
 
+			columnTypes, err := rows.ColumnTypes()
+			s.r.NoError(err)
+			s.r.Len(columnTypes, 1)
+			s.r.Equal("Timestamp NULL", columnTypes[0].DatabaseTypeName())
+			s.r.Equal(reflect.TypeOf(time.Time{}), columnTypes[0].ScanType())
+
 			var output time.Time
 			err = rows.Scan(&output)
 			s.r.NoError(err)
@@ -184,6 +196,12 @@ func (s *DatabendTestSuite) TestTimestampTz() {
 			s.r.NoError(err)
 			s.r.True(rows.Next())
 			s.r.NoError(err)
+
+			columnTypes, err := rows.ColumnTypes()
+			s.r.NoError(err)
+			s.r.Len(columnTypes, 1)
+			s.r.Equal("Timestamp_Tz NULL", columnTypes[0].DatabaseTypeName())
+			s.r.Equal(reflect.TypeOf(time.Time{}), columnTypes[0].ScanType())
 
 			var output time.Time
 			err = rows.Scan(&output)
@@ -244,6 +262,122 @@ func (s *DatabendTestSuite) TestDecimal() {
 	s.r.NoError(rows.Close())
 }
 
+func (s *DatabendTestSuite) TestScalarMappings() {
+	db := sql.OpenDB(s.cfg)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT CAST(true AS BOOLEAN) AS b, CAST(12 AS Int8) AS i8, CAST(1234 AS Int16) AS i16, CAST(123456 AS Int32) AS i32, CAST(123456789 AS Int64) AS i64, CAST(12 AS UInt8) AS u8, CAST(1234 AS UInt16) AS u16, CAST(123456 AS UInt32) AS u32, CAST(123456789 AS UInt64) AS u64, CAST(12.5 AS Float32) AS f32, CAST(34.25 AS Float64) AS f64, CAST('hello' AS String) AS s")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	columnTypes, err := rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 12)
+
+	testCases := []struct {
+		index    int
+		dbType   string
+		scanType reflect.Type
+	}{
+		{index: 0, dbType: "Boolean", scanType: reflect.TypeOf(true)},
+		{index: 1, dbType: "Int8", scanType: reflect.TypeOf(int8(0))},
+		{index: 2, dbType: "Int16", scanType: reflect.TypeOf(int16(0))},
+		{index: 3, dbType: "Int32", scanType: reflect.TypeOf(int32(0))},
+		{index: 4, dbType: "Int64", scanType: reflect.TypeOf(int64(0))},
+		{index: 5, dbType: "UInt8", scanType: reflect.TypeOf(uint8(0))},
+		{index: 6, dbType: "UInt16", scanType: reflect.TypeOf(uint16(0))},
+		{index: 7, dbType: "UInt32", scanType: reflect.TypeOf(uint32(0))},
+		{index: 8, dbType: "UInt64", scanType: reflect.TypeOf(uint64(0))},
+		{index: 9, dbType: "Float32", scanType: reflect.TypeOf(float32(0))},
+		{index: 10, dbType: "Float64", scanType: reflect.TypeOf(float64(0))},
+		{index: 11, dbType: "String", scanType: reflect.TypeOf("")},
+	}
+
+	for _, tc := range testCases {
+		s.r.Equal(tc.dbType, columnTypes[tc.index].DatabaseTypeName())
+		s.r.Equal(tc.scanType, columnTypes[tc.index].ScanType())
+		nullable, ok := columnTypes[tc.index].Nullable()
+		s.r.True(ok)
+		s.r.False(nullable)
+	}
+
+	var (
+		b   bool
+		i8  int8
+		i16 int16
+		i32 int32
+		i64 int64
+		u8  uint8
+		u16 uint16
+		u32 uint32
+		u64 uint64
+		f32 float32
+		f64 float64
+		str string
+	)
+	err = rows.Scan(&b, &i8, &i16, &i32, &i64, &u8, &u16, &u32, &u64, &f32, &f64, &str)
+	s.r.NoError(err)
+	s.r.True(b)
+	s.r.Equal(int8(12), i8)
+	s.r.Equal(int16(1234), i16)
+	s.r.Equal(int32(123456), i32)
+	s.r.Equal(int64(123456789), i64)
+	s.r.Equal(uint8(12), u8)
+	s.r.Equal(uint16(1234), u16)
+	s.r.Equal(uint32(123456), u32)
+	s.r.Equal(uint64(123456789), u64)
+	s.r.Equal(float32(12.5), f32)
+	s.r.Equal(float64(34.25), f64)
+	s.r.Equal("hello", str)
+	s.r.NoError(rows.Close())
+}
+
+func (s *DatabendTestSuite) TestNullableScalarMappings() {
+	db := sql.OpenDB(s.cfg)
+	defer db.Close()
+
+	rows, err := db.Query("SELECT CAST(NULL AS Nullable(Boolean)) AS b, CAST(NULL AS Nullable(Int64)) AS i64, CAST(NULL AS Nullable(Float64)) AS f64, CAST(NULL AS Nullable(String)) AS s")
+	s.r.NoError(err)
+	s.r.True(rows.Next())
+
+	columnTypes, err := rows.ColumnTypes()
+	s.r.NoError(err)
+	s.r.Len(columnTypes, 4)
+
+	testCases := []struct {
+		index    int
+		dbType   string
+		scanType reflect.Type
+	}{
+		{index: 0, dbType: "Boolean NULL", scanType: reflect.TypeOf(true)},
+		{index: 1, dbType: "Int64 NULL", scanType: reflect.TypeOf(int64(0))},
+		{index: 2, dbType: "Float64 NULL", scanType: reflect.TypeOf(float64(0))},
+		{index: 3, dbType: "String NULL", scanType: reflect.TypeOf("")},
+	}
+
+	for _, tc := range testCases {
+		s.r.Equal(tc.dbType, columnTypes[tc.index].DatabaseTypeName())
+		s.r.Equal(tc.scanType, columnTypes[tc.index].ScanType())
+		nullable, ok := columnTypes[tc.index].Nullable()
+		s.r.True(ok)
+		s.r.True(nullable)
+	}
+
+	var (
+		b   sql.NullBool
+		i64 sql.NullInt64
+		f64 sql.NullFloat64
+		str sql.NullString
+	)
+	err = rows.Scan(&b, &i64, &f64, &str)
+	s.r.NoError(err)
+	s.r.False(b.Valid)
+	s.r.False(i64.Valid)
+	s.r.False(f64.Valid)
+	s.r.False(str.Valid)
+	s.r.NoError(rows.Close())
+}
+
 func (s *DatabendTestSuite) TestGeo() {
 	db := sql.OpenDB(s.cfg)
 	defer db.Close()
@@ -254,40 +388,51 @@ func (s *DatabendTestSuite) TestGeo() {
 		geographyWKT = "POINT(60 37)"
 	)
 
-	rows, err := db.Query("settings(geometry_output_format='WKB') SELECT to_geometry('POINT(60 37)'), to_geography('POINT(60 37)')")
+	rows, err := db.Query("settings(geometry_output_format='WKB') SELECT to_geometry('POINT(60 37)'), CAST(NULL AS Geometry), to_geography('POINT(60 37)'), CAST(NULL AS Geography)")
 	s.r.NoError(err)
 	s.r.True(rows.Next())
 
 	columnTypes, err := rows.ColumnTypes()
 	s.r.NoError(err)
-	s.r.Len(columnTypes, 2)
+	s.r.Len(columnTypes, 4)
 	s.r.Equal("Geometry", columnTypes[0].DatabaseTypeName())
-	s.r.Equal("Geography", columnTypes[1].DatabaseTypeName())
+	s.r.Equal("Geometry NULL", columnTypes[1].DatabaseTypeName())
+	s.r.Equal("Geography", columnTypes[2].DatabaseTypeName())
+	s.r.Equal("Geography NULL", columnTypes[3].DatabaseTypeName())
 	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[0].ScanType())
 	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[1].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[2].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[3].ScanType())
 
-	var geomWKB, geogWKB []byte
-	err = rows.Scan(&geomWKB, &geogWKB)
+	var geomWKB, geomNull, geogWKB, geogNull []byte
+	err = rows.Scan(&geomWKB, &geomNull, &geogWKB, &geogNull)
 	s.r.NoError(err)
 	s.r.Equal(wkbHex, hex.EncodeToString(geomWKB))
+	s.r.Nil(geomNull)
 	s.r.Equal(wkbHex, hex.EncodeToString(geogWKB))
+	s.r.Nil(geogNull)
 	s.r.NoError(rows.Close())
 
-	rows, err = db.Query("settings(geometry_output_format='WKT') SELECT to_geometry('POINT(60 37)'), to_geography('POINT(60 37)')")
+	rows, err = db.Query("settings(geometry_output_format='WKT') SELECT to_geometry('POINT(60 37)'), CAST(NULL AS Geometry), to_geography('POINT(60 37)'), CAST(NULL AS Geography)")
 	s.r.NoError(err)
 	s.r.True(rows.Next())
 
 	columnTypes, err = rows.ColumnTypes()
 	s.r.NoError(err)
-	s.r.Len(columnTypes, 2)
+	s.r.Len(columnTypes, 4)
 	s.r.Equal(reflect.TypeOf(""), columnTypes[0].ScanType())
 	s.r.Equal(reflect.TypeOf(""), columnTypes[1].ScanType())
+	s.r.Equal(reflect.TypeOf(""), columnTypes[2].ScanType())
+	s.r.Equal(reflect.TypeOf(""), columnTypes[3].ScanType())
 
 	var geomText, geogText string
-	err = rows.Scan(&geomText, &geogText)
+	var geomNullText, geogNullText sql.NullString
+	err = rows.Scan(&geomText, &geomNullText, &geogText, &geogNullText)
 	s.r.NoError(err)
 	s.r.Equal(geometryWKT, geomText)
+	s.r.False(geomNullText.Valid)
 	s.r.Equal(geographyWKT, geogText)
+	s.r.False(geogNullText.Valid)
 	s.r.NoError(rows.Close())
 }
 
@@ -295,29 +440,38 @@ func (s *DatabendTestSuite) TestBinary() {
 	db := sql.OpenDB(s.cfg)
 	defer db.Close()
 
-	rows, err := db.Query("settings(binary_output_format='base64') SELECT to_binary('hello')")
+	rows, err := db.Query("settings(binary_output_format='base64') SELECT to_binary(''), to_binary('hello'), CAST(NULL AS Binary)")
 	s.r.NoError(err)
 	s.r.True(rows.Next())
 
 	columnTypes, err := rows.ColumnTypes()
 	s.r.NoError(err)
-	s.r.Len(columnTypes, 1)
+	s.r.Len(columnTypes, 3)
 	s.r.Equal("Binary", columnTypes[0].DatabaseTypeName())
+	s.r.Equal("Binary", columnTypes[1].DatabaseTypeName())
+	s.r.Equal("Binary NULL", columnTypes[2].DatabaseTypeName())
 	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[0].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[1].ScanType())
+	s.r.Equal(reflect.TypeOf([]byte(nil)), columnTypes[2].ScanType())
 
-	var raw []byte
-	err = rows.Scan(&raw)
+	var emptyRaw, raw, nullRaw []byte
+	err = rows.Scan(&emptyRaw, &raw, &nullRaw)
 	s.r.NoError(err)
+	s.r.Empty(emptyRaw)
 	s.r.Equal([]byte("hello"), raw)
+	s.r.Nil(nullRaw)
 	s.r.NoError(rows.Close())
 
-	rows, err = db.Query("settings(binary_output_format='base64') SELECT to_binary('hello')")
+	rows, err = db.Query("settings(binary_output_format='base64') SELECT to_binary(''), to_binary('hello'), CAST(NULL AS Binary)")
 	s.r.NoError(err)
 	s.r.True(rows.Next())
 
-	var text string
-	err = rows.Scan(&text)
+	var emptyText, text string
+	var nullText sql.NullString
+	err = rows.Scan(&emptyText, &text, &nullText)
 	s.r.NoError(err)
+	s.r.Equal("", emptyText)
 	s.r.Equal("hello", text)
+	s.r.False(nullText.Valid)
 	s.r.NoError(rows.Close())
 }


### PR DESCRIPTION

## Summary

  - Stabilize integration tests by removing shared resource collisions
  - Expand `type_test` integration coverage for scalar and nullable scalar mappings
  - Add integration coverage for restored client state behavior

  ## Changes

  - Use unique table names in suite setup and transaction/affected-rows tests to avoid cross-run interference
  - Use unique role names in role-switch integration tests
  - Make cleanup resilient with `DROP ... IF EXISTS`
  - Add scalar mapping integration assertions for:
    - `Boolean`
    - `Int8`, `Int16`, `Int32`, `Int64`
    - `UInt8`, `UInt16`, `UInt32`, `UInt64`
    - `Float32`, `Float64`
    - `String`
  - Add nullable scalar mapping integration assertions for:
    - `Nullable(Boolean)`
    - `Nullable(Int64)`
    - `Nullable(Float64)`
    - `Nullable(String)`
  - Add integration tests covering:
    - resumed query pagination with restored client state
    - restored session settings on a new client

  ## Validation

  - `go test ./...`
  - `make integration`
  - `make integration TEST_QUERY_RESULT_FORMAT=arrow`